### PR TITLE
Use only first answer when calculating length of alternate answers

### DIFF
--- a/src/qti/qti-elements/textEntryInteraction.js
+++ b/src/qti/qti-elements/textEntryInteraction.js
@@ -29,7 +29,7 @@ export default class textEntryInteraction {
   }
 
   get answerLength() {
-    return String(this.answer).length;
+    return String(this.answer[0]).length;
   }
 
   generateDOMNode() {


### PR DESCRIPTION
For text entry questions with alternate answers, the width of the input box was being set by the length of all the alternates together. It is now set by the length of the first alternate.