### PR TITLE
BUG-MCQ-questions

### DIFF
--- a/src/qti/qti-parser.js
+++ b/src/qti/qti-parser.js
@@ -175,8 +175,8 @@ class QTIParser {
   extractAnswerValueFromNode(node, questionNode, humanReadable) {
     let value;
     
-    if(node.attributes.hasOwnProperty('choiceIdentifier')) {
-      const identifier = node.getAttribute('choiceIdentifier');
+    if(node.attributes.hasOwnProperty('choiceIdentifier') || node.attributes.hasOwnProperty('choiceidentifier') ) {
+      const identifier = node.getAttribute('choiceIdentifier') || node.getAttribute('choiceidentifier');
       value = humanReadable ?
         this.extractHumanReadableChoice(questionNode, identifier) :
         identifier;


### PR DESCRIPTION
It looks like the attribute choiceIdentifier gets replaces with choiceidentifier (note change in capitalisation) in some browsers.
I've updated the getValidAnswer function to accept either option.